### PR TITLE
Create NoDrama Records skeleton pages

### DIFF
--- a/artists.html
+++ b/artists.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NoDrama Records</title>
-  <meta name="description" content="Independent record label based in San Francisco."/>
-  <meta property="og:title" content="NoDrama Records"/>
-  <meta property="og:description" content="Independent record label based in San Francisco."/>
-  <meta property="og:type" content="website"/>
-  <link rel="stylesheet" href="cdn/shop/t/64/assets/theme125f.css">
+  <title>Artists | NoDrama Records</title>
   <link rel="stylesheet" href="nodrama.css">
 </head>
 <body>
@@ -26,14 +21,12 @@
   </header>
   <main>
     <section>
-      <h1>NoDrama Records</h1>
-      <p>Independent record label and creative collective in San Francisco.</p>
-      <a class="cta-button" href="sms:+15555555555">Subscribe to Event Alerts!</a>
+      <h1>Artists</h1>
+      <p>Artist roster will be displayed here.</p>
     </section>
   </main>
   <footer>
     <p>© 2025 NoDrama Records</p>
-    <p><a href="https://instagram.com/nodramasf" target="_blank">Instagram</a></p>
   </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NoDrama Records</title>
-  <meta name="description" content="Independent record label based in San Francisco."/>
-  <meta property="og:title" content="NoDrama Records"/>
-  <meta property="og:description" content="Independent record label based in San Francisco."/>
-  <meta property="og:type" content="website"/>
-  <link rel="stylesheet" href="cdn/shop/t/64/assets/theme125f.css">
+  <title>Contact | NoDrama Records</title>
   <link rel="stylesheet" href="nodrama.css">
 </head>
 <body>
@@ -26,14 +21,12 @@
   </header>
   <main>
     <section>
-      <h1>NoDrama Records</h1>
-      <p>Independent record label and creative collective in San Francisco.</p>
-      <a class="cta-button" href="sms:+15555555555">Subscribe to Event Alerts!</a>
+      <h1>Contact</h1>
+      <p>Reach out via <a href="mailto:info@nodramasf.com">info@nodramasf.com</a>.</p>
     </section>
   </main>
   <footer>
     <p>© 2025 NoDrama Records</p>
-    <p><a href="https://instagram.com/nodramasf" target="_blank">Instagram</a></p>
   </footer>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NoDrama Records</title>
-  <meta name="description" content="Independent record label based in San Francisco."/>
-  <meta property="og:title" content="NoDrama Records"/>
-  <meta property="og:description" content="Independent record label based in San Francisco."/>
-  <meta property="og:type" content="website"/>
-  <link rel="stylesheet" href="cdn/shop/t/64/assets/theme125f.css">
+  <title>Events | NoDrama Records</title>
   <link rel="stylesheet" href="nodrama.css">
 </head>
 <body>
@@ -26,14 +21,12 @@
   </header>
   <main>
     <section>
-      <h1>NoDrama Records</h1>
-      <p>Independent record label and creative collective in San Francisco.</p>
-      <a class="cta-button" href="sms:+15555555555">Subscribe to Event Alerts!</a>
+      <h1>Events</h1>
+      <p>Upcoming and past events will be listed here.</p>
     </section>
   </main>
   <footer>
     <p>© 2025 NoDrama Records</p>
-    <p><a href="https://instagram.com/nodramasf" target="_blank">Instagram</a></p>
   </footer>
 </body>
 </html>

--- a/nodrama.css
+++ b/nodrama.css
@@ -1,0 +1,43 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #000;
+  color: #fff;
+}
+header {
+  background-color: #111;
+  padding: 10px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+nav a {
+  color: #fff;
+  margin: 0 10px;
+  text-decoration: none;
+  font-weight: bold;
+}
+nav a:hover {
+  color: #0af;
+}
+.cta-button {
+  display: inline-block;
+  background-color: #0af;
+  color: #000;
+  padding: 10px 20px;
+  margin-top: 20px;
+  border-radius: 4px;
+  text-decoration: none;
+}
+.cta-button:hover {
+  opacity: 0.8;
+}
+section {
+  padding: 20px;
+}
+footer {
+  text-align: center;
+  padding: 20px;
+  background-color: #111;
+}

--- a/podcasts.html
+++ b/podcasts.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NoDrama Records</title>
-  <meta name="description" content="Independent record label based in San Francisco."/>
-  <meta property="og:title" content="NoDrama Records"/>
-  <meta property="og:description" content="Independent record label based in San Francisco."/>
-  <meta property="og:type" content="website"/>
-  <link rel="stylesheet" href="cdn/shop/t/64/assets/theme125f.css">
+  <title>Podcasts | NoDrama Records</title>
   <link rel="stylesheet" href="nodrama.css">
 </head>
 <body>
@@ -26,14 +21,12 @@
   </header>
   <main>
     <section>
-      <h1>NoDrama Records</h1>
-      <p>Independent record label and creative collective in San Francisco.</p>
-      <a class="cta-button" href="sms:+15555555555">Subscribe to Event Alerts!</a>
+      <h1>Podcasts & Streams</h1>
+      <p>Stay tuned for upcoming podcasts and live streams.</p>
     </section>
   </main>
   <footer>
     <p>© 2025 NoDrama Records</p>
-    <p><a href="https://instagram.com/nodramasf" target="_blank">Instagram</a></p>
   </footer>
 </body>
 </html>

--- a/releases.html
+++ b/releases.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NoDrama Records</title>
-  <meta name="description" content="Independent record label based in San Francisco."/>
-  <meta property="og:title" content="NoDrama Records"/>
-  <meta property="og:description" content="Independent record label based in San Francisco."/>
-  <meta property="og:type" content="website"/>
-  <link rel="stylesheet" href="cdn/shop/t/64/assets/theme125f.css">
+  <title>Releases | NoDrama Records</title>
   <link rel="stylesheet" href="nodrama.css">
 </head>
 <body>
@@ -26,14 +21,12 @@
   </header>
   <main>
     <section>
-      <h1>NoDrama Records</h1>
-      <p>Independent record label and creative collective in San Francisco.</p>
-      <a class="cta-button" href="sms:+15555555555">Subscribe to Event Alerts!</a>
+      <h1>Releases</h1>
+      <p>Catalog of releases will be available here.</p>
     </section>
   </main>
   <footer>
     <p>© 2025 NoDrama Records</p>
-    <p><a href="https://instagram.com/nodramasf" target="_blank">Instagram</a></p>
   </footer>
 </body>
 </html>

--- a/studio.html
+++ b/studio.html
@@ -3,12 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>NoDrama Records</title>
-  <meta name="description" content="Independent record label based in San Francisco."/>
-  <meta property="og:title" content="NoDrama Records"/>
-  <meta property="og:description" content="Independent record label based in San Francisco."/>
-  <meta property="og:type" content="website"/>
-  <link rel="stylesheet" href="cdn/shop/t/64/assets/theme125f.css">
+  <title>Studio | NoDrama Records</title>
   <link rel="stylesheet" href="nodrama.css">
 </head>
 <body>
@@ -26,14 +21,13 @@
   </header>
   <main>
     <section>
-      <h1>NoDrama Records</h1>
-      <p>Independent record label and creative collective in San Francisco.</p>
-      <a class="cta-button" href="sms:+15555555555">Subscribe to Event Alerts!</a>
+      <h1>BoothSF Studio</h1>
+      <p>Information about the studio and booking details coming soon.</p>
+      <a class="cta-button" href="https://boothsf.com/" target="_blank">Book Studio Now</a>
     </section>
   </main>
   <footer>
     <p>© 2025 NoDrama Records</p>
-    <p><a href="https://instagram.com/nodramasf" target="_blank">Instagram</a></p>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace old index page with NoDrama Records landing page
- add simple navigation and event alerts CTA
- scaffold additional pages (Events, Artists, Releases, Studio, Contact, Podcasts)
- include minimal dark theme styling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6875d5e8bc60832ea2213ee220ac55d0