### PR TITLE
Add minimal NoDrama site skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# NoDrama-Landing-v2
+# NoDrama Landing
+
+This repository contains static assets for the NoDrama Records website. The `nodrama-site` directory provides a minimal dark-themed layout including pages for events, artists, releases, merch, studio info, and contact. The homepage highlights a prominent SMS subscription link for event alerts.
+
+The original export from BlackBookRecs.com is preserved for reference. Future development should expand on these pages, integrate a CMS and merchandise store, and migrate any existing functionality.

--- a/nodrama-site/artists.html
+++ b/nodrama-site/artists.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records - Artists</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Artists</h1>
+    <p>Content coming soon.</p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/contact.html
+++ b/nodrama-site/contact.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records - Contact</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Contact</h1>
+    <p>Content coming soon.</p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/events.html
+++ b/nodrama-site/events.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records - Events</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Events</h1>
+    <p>Content coming soon.</p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/index.html
+++ b/nodrama-site/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Welcome to NoDrama Records</h1>
+    <p>The new hub for our artists, events, and releases.</p>
+    <p><a class="cta" href="sms:+15555555555?&body=Subscribe">Subscribe to Event Alerts!</a></p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/merch.html
+++ b/nodrama-site/merch.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records - Merch</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Merch</h1>
+    <p>Content coming soon.</p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/podcasts.html
+++ b/nodrama-site/podcasts.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records - Podcasts</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Podcasts</h1>
+    <p>Content coming soon.</p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/releases.html
+++ b/nodrama-site/releases.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records - Releases</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Releases</h1>
+    <p>Content coming soon.</p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/studio.html
+++ b/nodrama-site/studio.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NoDrama Records - Studio</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <div class="logo">NoDrama Records</div>
+    <nav>
+      <a href="index.html">Home</a>
+      <a href="events.html">Events</a>
+      <a href="artists.html">Artists</a>
+      <a href="releases.html">Releases</a>
+      <a href="merch.html">Merch</a>
+      <a href="studio.html">Studio</a>
+      <a href="contact.html">Contact</a>
+    </nav>
+  </header>
+  <main>
+    <h1>Studio</h1>
+    <p>Content coming soon.</p>
+  </main>
+  <footer>
+    <a href="https://instagram.com/nodramasf">Instagram</a> |
+    <a href="mailto:info@nodramasf.com">Email</a>
+  </footer>
+</body>
+</html>

--- a/nodrama-site/style.css
+++ b/nodrama-site/style.css
@@ -1,0 +1,40 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #0a0a0a;
+  color: #f0f0f0;
+}
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background-color: #111;
+  position: sticky;
+  top: 0;
+}
+nav a {
+  color: #f0f0f0;
+  margin: 0 0.5rem;
+  text-decoration: none;
+}
+nav a:hover {
+  color: #4ca1ff;
+}
+.cta {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background-color: #4ca1ff;
+  color: #000;
+  text-decoration: none;
+  border-radius: 4px;
+}
+main {
+  padding: 2rem;
+}
+footer {
+  text-align: center;
+  padding: 1rem;
+  background-color: #111;
+  margin-top: 2rem;
+}


### PR DESCRIPTION
## Summary
- flesh out README with instructions about new NoDrama site
- create `nodrama-site` with a basic dark themed layout
- add placeholder pages for events, artists, releases, merch, studio, contact, and podcasts
- include SMS subscription button on the homepage

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6875d5e8bc60832ea2213ee220ac55d0